### PR TITLE
Remove numpy pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: abe467b92481a9f836d34f057c6fd89c4352aea8ff99b7cd3c03ac900da3eb27
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - imageio
     - matplotlib-base
     - numba
-    - numpy <=1.20,>=1.17
+    - numpy
     - psutil
     - pyfftw
     - python >=3.6


### PR DESCRIPTION
The numpy pinning has been removed in https://github.com/jacobjma/abTEM/commit/7c6b618410ae04b646e2288c7af0fd1863f6f8b7.
FYI @jacobjma.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [n/a] Reset the build number to `0` (if the version changed)
* [n/a] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [n/a] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
